### PR TITLE
Replacing lock_guard with scoped_lock.

### DIFF
--- a/src/p2p/p2p.cpp
+++ b/src/p2p/p2p.cpp
@@ -89,7 +89,7 @@ namespace p2p
         // If pub key is lower than our id (> 0), then we should give priority to any existing outbound connection
         // from the same peer and drop the inbound connection.
 
-        std::lock_guard<std::mutex> lock(ctx.peer_connections_mutex);
+        std::scoped_lock<std::mutex> lock(ctx.peer_connections_mutex);
 
         const auto iter = p2p::ctx.peer_connections.find(pubkeyhex);
         if (iter == p2p::ctx.peer_connections.end())
@@ -159,7 +159,7 @@ namespace p2p
         }
 
         //Broadcast while locking the peer_connections.
-        std::lock_guard<std::mutex> lock(ctx.peer_connections_mutex);
+        std::scoped_lock<std::mutex> lock(ctx.peer_connections_mutex);
 
         for (const auto &[k, session] : ctx.peer_connections)
         {
@@ -179,7 +179,7 @@ namespace p2p
     void send_message_to_self(const flatbuffers::FlatBufferBuilder &fbuf)
     {
         //Send while locking the peer_connections.
-        std::lock_guard<std::mutex> lock(p2p::ctx.peer_connections_mutex);
+        std::scoped_lock<std::mutex> lock(p2p::ctx.peer_connections_mutex);
 
         // Find the peer session connected to self.
         const auto peer_itr = ctx.peer_connections.find(conf::cfg.pubkeyhex);
@@ -200,7 +200,7 @@ namespace p2p
     void send_message_to_random_peer(const flatbuffers::FlatBufferBuilder &fbuf)
     {
         //Send while locking the peer_connections.
-        std::lock_guard<std::mutex> lock(p2p::ctx.peer_connections_mutex);
+        std::scoped_lock<std::mutex> lock(p2p::ctx.peer_connections_mutex);
 
         const size_t connected_peers = ctx.peer_connections.size();
         if (connected_peers == 0)

--- a/src/p2p/peer_session_handler.cpp
+++ b/src/p2p/peer_session_handler.cpp
@@ -113,14 +113,14 @@ namespace p2p
                 return 0;
             }
 
-            std::lock_guard<std::mutex> lock(ctx.collected_msgs.proposals_mutex); // Insert proposal with lock.
+            std::scoped_lock<std::mutex> lock(ctx.collected_msgs.proposals_mutex); // Insert proposal with lock.
 
             ctx.collected_msgs.proposals.push_back(
                 p2pmsg::create_proposal_from_msg(*content->message_as_Proposal_Message(), container->pubkey(), container->timestamp(), container->lcl()));
         }
         else if (content_message_type == p2pmsg::Message_NonUnl_Proposal_Message) //message is a non-unl proposal message
         {
-            std::lock_guard<std::mutex> lock(ctx.collected_msgs.nonunl_proposals_mutex); // Insert non-unl proposal with lock.
+            std::scoped_lock<std::mutex> lock(ctx.collected_msgs.nonunl_proposals_mutex); // Insert non-unl proposal with lock.
 
             ctx.collected_msgs.nonunl_proposals.push_back(
                 p2pmsg::create_nonunl_proposal_from_msg(*content->message_as_NonUnl_Proposal_Message(), container->timestamp()));
@@ -133,7 +133,7 @@ namespace p2p
                 return 0;
             }
 
-            std::lock_guard<std::mutex> lock(ctx.collected_msgs.npl_messages_mutex); // Insert npl message with lock.
+            std::scoped_lock<std::mutex> lock(ctx.collected_msgs.npl_messages_mutex); // Insert npl message with lock.
 
             const p2pmsg::Npl_Message *npl_p2p_msg = content->message_as_Npl_Message();
             npl_message msg;
@@ -151,7 +151,7 @@ namespace p2p
             }
 
             // Insert request with lock.
-            std::lock_guard<std::mutex> lock(ctx.collected_msgs.state_requests_mutex);
+            std::scoped_lock<std::mutex> lock(ctx.collected_msgs.state_requests_mutex);
             std::string state_request_msg(reinterpret_cast<const char *>(content_ptr), content_size);
             ctx.collected_msgs.state_requests.push_back(std::make_pair(session.uniqueid, std::move(state_request_msg)));
         }
@@ -166,7 +166,7 @@ namespace p2p
             if (state_sync::ctx.is_syncing) // Only accept state responses if state is syncing.
             {
                 // Insert state_response with lock.
-                std::lock_guard<std::mutex> lock(ctx.collected_msgs.state_responses_mutex);
+                std::scoped_lock<std::mutex> lock(ctx.collected_msgs.state_responses_mutex);
                 std::string response(reinterpret_cast<const char *>(content_ptr), content_size);
                 ctx.collected_msgs.state_responses.push_back(std::move(response));
             }
@@ -215,7 +215,7 @@ namespace p2p
     void peer_session_handler::on_close(const comm::comm_session &session) const
     {
         // Erase the corresponding uniqueid peer connection if it's this session.
-        std::lock_guard<std::mutex> lock(ctx.peer_connections_mutex);
+        std::scoped_lock<std::mutex> lock(ctx.peer_connections_mutex);
         const auto itr = ctx.peer_connections.find(session.uniqueid);
         if (itr != ctx.peer_connections.end() && itr->second == &session)
             ctx.peer_connections.erase(itr);

--- a/src/state/state_serve.cpp
+++ b/src/state/state_serve.cpp
@@ -56,7 +56,7 @@ namespace state_serve
             util::sleep(LOOP_WAIT);
 
             {
-                std::lock_guard<std::mutex> lock(p2p::ctx.collected_msgs.state_requests_mutex);
+                std::scoped_lock<std::mutex> lock(p2p::ctx.collected_msgs.state_requests_mutex);
 
                 // Move collected state requests over to local requests list.
                 if (!p2p::ctx.collected_msgs.state_requests.empty())
@@ -85,7 +85,7 @@ namespace state_serve
                 if (state_serve::create_state_response(fbuf, sr) == 0)
                 {
                     // Find the peer that we should send the state response to.
-                    std::lock_guard<std::mutex> lock(p2p::ctx.peer_connections_mutex);
+                    std::scoped_lock<std::mutex> lock(p2p::ctx.peer_connections_mutex);
                     const auto peer_itr = p2p::ctx.peer_connections.find(session_id);
 
                     if (peer_itr != p2p::ctx.peer_connections.end())

--- a/src/state/state_sync.cpp
+++ b/src/state/state_sync.cpp
@@ -55,7 +55,7 @@ namespace state_sync
  */
     void set_target(const hpfs::h32 target_state, void (*const completion_callback)(const hpfs::h32))
     {
-        std::lock_guard<std::mutex> lock(ctx.target_state_update_lock);
+        std::scoped_lock<std::mutex> lock(ctx.target_state_update_lock);
 
         // Do not do anything if we are already syncing towards the specified target state.
         if (ctx.is_shutting_down || (ctx.is_syncing && ctx.target_state == target_state))
@@ -81,7 +81,7 @@ namespace state_sync
 
             // Keep idling if we are not doing any sync activity.
             {
-                std::lock_guard<std::mutex> lock(ctx.target_state_update_lock);
+                std::scoped_lock<std::mutex> lock(ctx.target_state_update_lock);
                 if (!ctx.is_syncing)
                     continue;
 
@@ -104,7 +104,7 @@ namespace state_sync
                     ctx.submitted_requests.clear();
 
                     {
-                        std::lock_guard<std::mutex> lock(ctx.target_state_update_lock);
+                        std::scoped_lock<std::mutex> lock(ctx.target_state_update_lock);
 
                         if (new_state == ctx.target_state)
                         {
@@ -146,7 +146,7 @@ namespace state_sync
             util::sleep(REQUEST_LOOP_WAIT);
 
             {
-                std::lock_guard<std::mutex> lock(p2p::ctx.collected_msgs.state_responses_mutex);
+                std::scoped_lock<std::mutex> lock(p2p::ctx.collected_msgs.state_responses_mutex);
 
                 // Move collected state responses over to local candidate responses list.
                 if (!p2p::ctx.collected_msgs.state_responses.empty())
@@ -241,7 +241,7 @@ namespace state_sync
             return true;
 
         // Stop request loop if the target has changed.
-        std::lock_guard<std::mutex> lock(ctx.target_state_update_lock);
+        std::scoped_lock<std::mutex> lock(ctx.target_state_update_lock);
         return current_target != ctx.target_state;
     }
 

--- a/src/usr/read_req.cpp
+++ b/src/usr/read_req.cpp
@@ -136,7 +136,7 @@ namespace read_req
                 if (sc::execute_contract(*context_itr) != -1)
                 {
                     // If contract execution was succcessful, send the output back to user.
-                    std::lock_guard<std::mutex> lock(usr::ctx.users_mutex);
+                    std::scoped_lock<std::mutex> lock(usr::ctx.users_mutex);
 
                     const auto user_buf_itr = context_itr->args.userbufs.begin();
                     if (!user_buf_itr->second.output.empty())

--- a/src/usr/usr.cpp
+++ b/src/usr/usr.cpp
@@ -161,7 +161,7 @@ namespace usr
                 std::string sig;
                 if (parser.extract_signed_input_container(input_container, sig) == 0)
                 {
-                    std::lock_guard<std::mutex> lock(ctx.users_mutex);
+                    std::scoped_lock<std::mutex> lock(ctx.users_mutex);
 
                     //Add to the submitted input list.
                     user.submitted_inputs.push_back(user_input(
@@ -228,7 +228,7 @@ namespace usr
         }
 
         {
-            std::lock_guard<std::mutex> lock(ctx.users_mutex);
+            std::scoped_lock<std::mutex> lock(ctx.users_mutex);
             ctx.users.emplace(sessionid, usr::connected_user(session, pubkey, protocol));
         }
 
@@ -258,7 +258,7 @@ namespace usr
         usr::connected_user &user = itr->second;
 
         {
-            std::lock_guard<std::mutex> lock(ctx.users_mutex);
+            std::scoped_lock<std::mutex> lock(ctx.users_mutex);
             ctx.sessionids.erase(user.pubkey);
         }
 


### PR DESCRIPTION
Replaced lock_guard from new scoped_lock in C++17.