### PR TITLE
Idle connection timeout config for both peer and user connections.

### DIFF
--- a/src/comm/comm_server.hpp
+++ b/src/comm/comm_server.hpp
@@ -16,7 +16,7 @@ namespace comm
     class comm_server
     {
     protected:
-        const uint64_t (&metric_thresholds)[4];
+        const uint64_t (&metric_thresholds)[5];
         const uint64_t max_msg_size;
         bool is_shutting_down = false;
         std::list<T> sessions;
@@ -210,7 +210,7 @@ namespace comm
         }
 
     public:
-        comm_server(std::string_view name, const uint16_t port, const uint64_t (&metric_thresholds)[4], const uint64_t max_msg_size)
+        comm_server(std::string_view name, const uint16_t port, const uint64_t (&metric_thresholds)[5], const uint64_t max_msg_size)
             : name(name),
               listen_port(port),
               metric_thresholds(metric_thresholds),

--- a/src/comm/comm_session.hpp
+++ b/src/comm/comm_session.hpp
@@ -56,7 +56,7 @@ namespace comm
         uint64_t last_activity_timestamp; // Keep track of the last activity timestamp in milliseconds.
 
         comm_session(
-            std::string_view host_address, hpws::client &&hpws_client, const bool is_inbound, const uint64_t (&metric_thresholds)[4]);
+            std::string_view host_address, hpws::client &&hpws_client, const bool is_inbound, const uint64_t (&metric_thresholds)[5]);
         int init();
         int process_next_inbound_message();
         int send(const std::vector<uint8_t> &message);

--- a/src/comm/comm_session_threshold.hpp
+++ b/src/comm/comm_session_threshold.hpp
@@ -21,7 +21,10 @@ enum SESSION_THRESHOLDS
     MAX_BADSIGMSGS_PER_MINUTE = 2,
 
     // Max messages with bad structure per minute.
-    MAX_BADMSGS_PER_MINUTE = 3
+    MAX_BADMSGS_PER_MINUTE = 3,
+
+    // Idle connection timeout.
+    IDLE_CONNECTION_TIMEOUT = 4
 };
 
 /*

--- a/src/conf.cpp
+++ b/src/conf.cpp
@@ -87,6 +87,8 @@ namespace conf
         cfg.roundtime = 1000;
         cfg.pubport = 8080;
         cfg.peerdiscoverytime = 30000;
+        cfg.pubidletimeout = 0;
+        cfg.peeridletimeout = 120;
 
         cfg.msgforwarding = false;
         cfg.dynamicpeerdiscovery = false;
@@ -284,6 +286,9 @@ namespace conf
         cfg.roundtime = d["roundtime"].as<uint16_t>();
         cfg.peerdiscoverytime = d["peerdiscoverytime"].as<uint16_t>();
 
+        cfg.peeridletimeout = d["peeridletimeout"].as<uint16_t>();
+        cfg.pubidletimeout = d["pubidletimeout"].as<uint16_t>();
+
         cfg.pubmaxsize = d["pubmaxsize"].as<uint64_t>();
         cfg.pubmaxcpm = d["pubmaxcpm"].as<uint64_t>();
         cfg.pubmaxbadmpm = d["pubmaxbadmpm"].as<uint64_t>();
@@ -363,6 +368,9 @@ namespace conf
         d.insert_or_assign("pubport", cfg.pubport);
         d.insert_or_assign("roundtime", cfg.roundtime);
         d.insert_or_assign("peerdiscoverytime", cfg.peerdiscoverytime);
+
+        d.insert_or_assign("peeridletimeout", cfg.peeridletimeout);
+        d.insert_or_assign("pubidletimeout", cfg.pubidletimeout);
 
         d.insert_or_assign("pubmaxsize", cfg.pubmaxsize);
         d.insert_or_assign("pubmaxcpm", cfg.pubmaxcpm);

--- a/src/conf.hpp
+++ b/src/conf.hpp
@@ -99,6 +99,9 @@ namespace conf
         uint16_t pubport = 0;                                   // Listening port for public user connections
         uint16_t peerdiscoverytime = 0;                         // Time interval in ms to find for peers dynamicpeerdiscovery should be on for this
 
+        uint16_t peeridletimeout = 0;   // Idle connection timeout for peer connections in seconds.
+        uint16_t pubidletimeout = 0;    // Idle connection timeout for user connections in seconds.
+
         uint64_t pubmaxsize = 0;   // User message max size in bytes
         uint64_t pubmaxcpm = 0;    // User message rate (characters(bytes) per minute)
         uint64_t pubmaxbadmpm = 0; // User bad messages per minute

--- a/src/p2p/p2p.cpp
+++ b/src/p2p/p2p.cpp
@@ -14,7 +14,7 @@ namespace p2p
     // Holds global connected-peers and related objects.
     connected_context ctx;
 
-    uint64_t metric_thresholds[4];
+    uint64_t metric_thresholds[5];
     bool init_success = false;
 
     /**
@@ -27,6 +27,7 @@ namespace p2p
         metric_thresholds[1] = conf::cfg.peermaxdupmpm;
         metric_thresholds[2] = conf::cfg.peermaxbadsigpm;
         metric_thresholds[3] = conf::cfg.peermaxbadmpm;
+        metric_thresholds[4] = conf::cfg.peeridletimeout;
 
         //Entry point for p2p which will start peer connections to other nodes
         if (start_peer_connections() == -1)

--- a/src/p2p/peer_comm_server.cpp
+++ b/src/p2p/peer_comm_server.cpp
@@ -12,7 +12,7 @@ namespace p2p
     // Globally exposed weakly connected status variable.
     bool is_weakly_connected = false;
 
-    peer_comm_server::peer_comm_server(const uint16_t port, const uint64_t (&metric_thresholds)[4],
+    peer_comm_server::peer_comm_server(const uint16_t port, const uint64_t (&metric_thresholds)[5],
                                        const uint64_t max_msg_size, std::vector<conf::peer_properties> &req_known_remotes)
         : comm::comm_server<peer_comm_session>("Peer", port, metric_thresholds, max_msg_size),
           req_known_remotes(req_known_remotes)

--- a/src/p2p/peer_comm_server.hpp
+++ b/src/p2p/peer_comm_server.hpp
@@ -31,7 +31,7 @@ namespace p2p
         std::atomic<uint16_t> known_remote_count = 0;
         std::mutex req_known_remotes_mutex;
         std::vector<conf::peer_properties> &req_known_remotes;
-        peer_comm_server(const uint16_t port, const uint64_t (&metric_thresholds)[4],
+        peer_comm_server(const uint16_t port, const uint64_t (&metric_thresholds)[5],
                          const uint64_t max_msg_size, std::vector<conf::peer_properties> &req_known_remotes);
     };
 } // namespace p2p

--- a/src/usr/usr.cpp
+++ b/src/usr/usr.cpp
@@ -20,7 +20,7 @@ namespace usr
     // Holds global connected-users and related objects.
     connected_context ctx;
 
-    uint64_t metric_thresholds[4];
+    uint64_t metric_thresholds[5];
     bool init_success = false;
 
     /**
@@ -33,6 +33,7 @@ namespace usr
         metric_thresholds[1] = 0;   // This metric doesn't apply to user context.
         metric_thresholds[2] = 0;   // This metric doesn't apply to user context.
         metric_thresholds[3] = conf::cfg.pubmaxbadmpm;
+        metric_thresholds[4] = conf::cfg.pubidletimeout;
 
         // Start listening for incoming user connections.
         if (start_listening() == -1)


### PR DESCRIPTION
- loading idle connection timeout for verified connections from config file for both user and peer connections.
- User connection timeout defaults to zero.
- Peer connection timeout defaults to two minutes.