### PR TITLE
Stopped skipping self pub key from the config unl

### DIFF
--- a/src/conf.cpp
+++ b/src/conf.cpp
@@ -91,6 +91,9 @@ namespace conf
         crypto::generate_signing_keys(cfg.pubkey, cfg.seckey);
         binpair_to_hex(cfg);
 
+        //Add self pubkey to the unl.
+        cfg.unl.emplace(cfg.pubkey);
+
         cfg.operating_mode = OPERATING_MODE::PROPOSER;
         cfg.peerport = 22860;
         cfg.roundtime = 1000;
@@ -364,8 +367,7 @@ namespace conf
                 reinterpret_cast<const unsigned char *>(nodepk.data()),
                 nodepk.length());
 
-            if (hex_pubkey != cfg.pubkeyhex)
-                unl.push_back(hex_pubkey); // We do not save our own pubkey in config file.
+            unl.push_back(hex_pubkey);
         }
         d.insert_or_assign("unl", unl);
 
@@ -450,8 +452,7 @@ namespace conf
             return -1;
         }
 
-        // Populate unl.
-        cfg.unl.emplace(cfg.pubkey); // Add self pubkey to unl.
+        // Populate unl.        
         unl::init(cfg.unl);
 
         // Populate runtime contract execution args.

--- a/test/local-cluster/cluster-create.sh
+++ b/test/local-cluster/cluster-create.sh
@@ -102,11 +102,17 @@ function joinarr {
     arr=("${!arrname}")
     skip=$2
 
+    let prevlast=$ncount-2
+    # Resetting prevlast if nothing is given to skip.
+    if [ $skip -lt 0 ]
+    then
+        let prevlast=prevlast+1
+    fi
+
     j=0
     str="["
     for (( i=0; i<$ncount; i++ ))
     do
-        let prevlast=$ncount-2
         if [ "$i" != "$skip" ]
         then
             str="$str'${arr[i]}'"
@@ -123,12 +129,13 @@ function joinarr {
     echo $str
 }
 
-# Loop through all nodes hp.cfg and inject peer and unl lists (skip self node).
+# Loop through all nodes hp.cfg and inject peer and unl lists (skip self node for peers).
 for (( j=0; j<$ncount; j++ ))
 do
     let n=$j+1
     mypeers=$(joinarr peers $j)
-    myunl=$(joinarr pubkeys $j)
+    # Skip param is passed as -1 to stop skipping self pubkey.
+    myunl=$(joinarr pubkeys -1)
 
     pushd ./node$n/cfg > /dev/null 2>&1
     mv hp.cfg tmp.json  # nodejs needs file extension to be .json

--- a/test/vm-cluster/cluster.sh
+++ b/test/vm-cluster/cluster.sh
@@ -307,11 +307,17 @@ function joinarr {
     arr=("${!arrname}")
     skip=$2
 
+    let prevlast=$ncount-2
+    # Resetting prevlast if nothing is given to skip.
+    if [ $skip -lt 0 ]
+    then
+        let prevlast=prevlast+1
+    fi
+
     j=0
     str="["
     for (( i=0; i<$vmcount; i++ ))
     do
-        let prevlast=$vmcount-2
         if [ "$i" != "$skip" ]
         then
             str="$str\"${arr[i]}\""
@@ -333,9 +339,10 @@ for (( j=0; j<$vmcount; j++ ))
 do
     let n=$j+1
 
-    # Prepare peer and unl lists (skip self node).
+    # Prepare peer and unl lists (skip self node for peers).
     mypeers=$(joinarr peers $j)
-    myunl=$(joinarr pubkeys $j)
+    # Skip param is passed as -1 to stop skipping self pubkey.
+    myunl=$(joinarr pubkeys -1)
 
     # Merge json contents to produce final contract config.
     echo "$(cat ./cfg/node$n.cfg)" \


### PR DESCRIPTION
- Adding self pubkey when generating the config.
- Remove adding self pubkey on runtime.
- Changed Cluster and VM create scripts accordingly. 