### PR TITLE
Adding support for contract config update via a patch file.

### DIFF
--- a/src/conf.hpp
+++ b/src/conf.hpp
@@ -197,7 +197,7 @@ namespace conf
 
     int apply_patch_changes(contract_params &contract_config);
 
-    int validate_and_apply_patch_config(contract_params &contract_config);
+    int validate_and_apply_patch_config(contract_params &contract_config, std::string_view mount_dir);
 } // namespace conf
 
 #endif


### PR DESCRIPTION
- Contract config section of the config file is updated if a patch file is detected in the root path.
- Changes are applied only if the patch file content is changed.
- Change is detected from the hash of patch file data.