### PR TITLE
Apply patch file changes only after consensus verification.

### DIFF
--- a/src/consensus.hpp
+++ b/src/consensus.hpp
@@ -95,7 +95,7 @@ namespace consensus
         std::map<util::h32, uint32_t> state_hash;
         std::map<util::h32, uint32_t> patch_hash;
     };
-    extern std::atomic<bool> is_patch_updating; // Keep track whether the patch file is changed by contract and is not yet applied to runtime.
+    extern std::atomic<bool> is_patch_update_pending; // Keep track whether the patch file is changed by the SC and is not yet applied to runtime.
 
     int init();
 

--- a/src/hpfs/hpfs.hpp
+++ b/src/hpfs/hpfs.hpp
@@ -40,8 +40,6 @@ namespace hpfs
     private:
         std::vector<util::h32> parent_hashes;                                             // Keep hashes of each hpfs parent.
         std::shared_mutex parent_mutexes[2] = {std::shared_mutex(), std::shared_mutex()}; // Mutexes for each parent.
-        util::h32 updated_patch_hash = util::h32_empty; 
-        std::shared_mutex patch_mutex;
 
     public:
         pid_t hpfs_pid = 0;

--- a/src/sc.cpp
+++ b/src/sc.cpp
@@ -191,7 +191,7 @@ namespace sc
                 // Update global hash tracker with the new patch file hash.
                 hpfs::ctx.set_hash(hpfs::HPFS_PARENT_COMPONENTS::PATCH, patch_hash);
                 // Denote that the patch file was updated by the SC.
-                consensus::is_patch_updating = true;
+                consensus::is_patch_update_pending = true;
             }
 
             return hpfs::release_rw_session();


### PR DESCRIPTION
Patch file changes from the contract are only applied after verified by consensus.