### PR TITLE
Removed legacy lcl code and dependencies

### DIFF
--- a/src/consensus.hpp
+++ b/src/consensus.hpp
@@ -125,10 +125,10 @@ namespace consensus
 
     int verify_and_populate_candidate_user_inputs(const uint64_t lcl_seq_no);
 
-    p2p::proposal create_stage0_proposal(std::string_view lcl, const util::h32 &state_hash, const util::h32 &patch_hash,
+    p2p::proposal create_stage0_proposal(const util::h32 &state_hash, const util::h32 &patch_hash,
                                          const p2p::sequence_hash &last_primary_shard_id, const p2p::sequence_hash &last_blob_shard_id);
 
-    p2p::proposal create_stage123_proposal(vote_counter &votes, std::string_view lcl, const size_t unl_count, const util::h32 &state_hash, const util::h32 &patch_hash,
+    p2p::proposal create_stage123_proposal(vote_counter &votes, const size_t unl_count, const util::h32 &state_hash, const util::h32 &patch_hash,
                                            const p2p::sequence_hash &last_primary_shard_id, const p2p::sequence_hash &last_blob_shard_id);
 
     void broadcast_proposal(const p2p::proposal &p);
@@ -147,9 +147,9 @@ namespace consensus
 
     uint64_t get_stage_time_resolution(const uint64_t time);
 
-    int update_ledger_and_execute_contract(const p2p::proposal &cons_prop, std::string &new_lcl, util::h32 &new_state_hash, const util::h32 &patch_hash);
+    int update_ledger_and_execute_contract(const p2p::proposal &cons_prop, util::h32 &new_state_hash, const util::h32 &patch_hash, p2p::sequence_hash &new_lcl_id);
 
-    int dispatch_user_outputs(const p2p::proposal &cons_prop, const uint64_t lcl_seq_no, std::string_view lcl);
+    int dispatch_user_outputs(const p2p::proposal &cons_prop, const p2p::sequence_hash lcl_id);
 
     int feed_user_inputs_to_contract_bufmap(sc::contract_bufmap_t &bufmap, const p2p::proposal &cons_prop);
 

--- a/src/hpfs/hpfs_serve.cpp
+++ b/src/hpfs/hpfs_serve.cpp
@@ -69,7 +69,7 @@ namespace hpfs
 
             prev_requests_processed = !hpfs_requests.empty();
             const uint64_t time_start = util::get_epoch_milliseconds();
-            const std::string lcl = ledger::ctx.get_lcl();
+            const p2p::sequence_hash lcl_id = ledger::ctx.get_lcl_id();
             const p2p::sequence_hash last_primary_shard_id = ledger::ctx.get_last_primary_shard_id();
             const uint32_t request_batch_timeout = hpfs::get_request_resubmit_timeout() * 0.9;
 
@@ -96,7 +96,7 @@ namespace hpfs
                     LOG_DEBUG << "Serving hpfs request from [" << util::to_hex(session_id).substr(2, 10) << "]";
                     flatbuffers::FlatBufferBuilder fbuf(1024);
 
-                    if (hpfs_serve::create_hpfs_response(fbuf, hr, lcl, last_primary_shard_id) == 1)
+                    if (hpfs_serve::create_hpfs_response(fbuf, hr, last_primary_shard_id) == 1)
                     {
                         // Find the peer that we should send the hpfs response to.
                         std::scoped_lock<std::mutex> lock(p2p::ctx.peer_connections_mutex);
@@ -125,12 +125,11 @@ namespace hpfs
      * Creates the reply message for a given hpfs request.
      * @param fbuf The flatbuffer builder to construct the reply message.
      * @param hr The hpfs request which should be replied to.
-     * @param lcl Our lcl.
      * @param last_primary_shard_id Last primary shard id.
      * @return 1 if successful hpfs response was generated. 0 if request is invalid
      *         and no response was generated. -1 on error.
      */
-    int hpfs_serve::create_hpfs_response(flatbuffers::FlatBufferBuilder &fbuf, const p2p::hpfs_request &hr, std::string_view lcl, const p2p::sequence_hash &last_primary_shard_id)
+    int hpfs_serve::create_hpfs_response(flatbuffers::FlatBufferBuilder &fbuf, const p2p::hpfs_request &hr, const p2p::sequence_hash &last_primary_shard_id)
     {
         LOG_DEBUG << "Serving hpfs req. path:" << hr.parent_path << " block_id:" << hr.block_id;
 
@@ -155,7 +154,7 @@ namespace hpfs
                 resp.hash = hr.expected_hash;
                 resp.data = std::string_view(reinterpret_cast<const char *>(block.data()), block.size());
 
-                msg::fbuf::p2pmsg::create_msg_from_block_response(fbuf, resp, fs_mount->mount_id, lcl, last_primary_shard_id);
+                msg::fbuf::p2pmsg::create_msg_from_block_response(fbuf, resp, fs_mount->mount_id, last_primary_shard_id);
                 return 1; // Success.
             }
         }
@@ -177,7 +176,7 @@ namespace hpfs
                 {
                     msg::fbuf::p2pmsg::create_msg_from_filehashmap_response(
                         fbuf, hr.parent_path, fs_mount->mount_id, block_hashes,
-                        file_length, hr.expected_hash, lcl, last_primary_shard_id);
+                        file_length, hr.expected_hash, last_primary_shard_id);
                     return 1; // Success.
                 }
             }
@@ -196,7 +195,7 @@ namespace hpfs
                 else if (result == 1)
                 {
                     msg::fbuf::p2pmsg::create_msg_from_fsentry_response(
-                        fbuf, hr.parent_path, fs_mount->mount_id, child_hash_nodes, hr.expected_hash, lcl, last_primary_shard_id);
+                        fbuf, hr.parent_path, fs_mount->mount_id, child_hash_nodes, hr.expected_hash, last_primary_shard_id);
                     return 1; // Success.
                 }
             }

--- a/src/hpfs/hpfs_serve.hpp
+++ b/src/hpfs/hpfs_serve.hpp
@@ -28,7 +28,7 @@ namespace hpfs
 
         void deinit();
 
-        int create_hpfs_response(flatbuffers::FlatBufferBuilder &fbuf, const p2p::hpfs_request &hr, std::string_view lcl, const p2p::sequence_hash &last_primary_shard_id);
+        int create_hpfs_response(flatbuffers::FlatBufferBuilder &fbuf, const p2p::hpfs_request &hr, const p2p::sequence_hash &last_primary_shard_id);
 
         int get_data_block(std::vector<uint8_t> &block, const std::string_view vpath,
                            const uint32_t block_id, const util::h32 expected_hash);

--- a/src/hpfs/hpfs_sync.hpp
+++ b/src/hpfs/hpfs_sync.hpp
@@ -109,9 +109,9 @@ namespace hpfs
         bool should_stop_request_loop(const util::h32 &current_target_hash);
 
         void request_state_from_peer(const std::string &path, const bool is_file, const int32_t block_id,
-                                            const util::h32 expected_hash, std::string_view lcl, const p2p::sequence_hash &last_primary_shard_id, std::string &target_pubkey);
+                                            const util::h32 expected_hash, const p2p::sequence_hash &last_primary_shard_id, std::string &target_pubkey);
 
-        void submit_request(const backlog_item &request, std::string_view lcl, const p2p::sequence_hash &last_primary_shard_id);
+        void submit_request(const backlog_item &request, const p2p::sequence_hash &last_primary_shard_id);
 
         int handle_fs_entry_response(std::string_view vpath, std::unordered_map<std::string, p2p::hpfs_fs_hash_entry> &fs_entry_map);
 

--- a/src/ledger/ledger.hpp
+++ b/src/ledger/ledger.hpp
@@ -9,7 +9,6 @@
 
 namespace ledger
 {
-    constexpr const char *GENESIS_LEDGER = "0-genesis";
     constexpr const char *DATEBASE = "ledger.sqlite";
     constexpr uint64_t PRIMARY_SHARD_SIZE = 4096;
     constexpr uint64_t BLOB_SHARD_SIZE = 4096;
@@ -20,31 +19,23 @@ namespace ledger
     {
     private:
         std::shared_mutex lcl_mutex;
-        std::string lcl;
-        uint64_t seq_no = 0;
+        p2p::sequence_hash lcl_id;
         std::shared_mutex last_primary_shard_mutex;
         p2p::sequence_hash last_primary_shard_id;
         std::shared_mutex last_blob_shard_mutex;
         p2p::sequence_hash last_blob_shard_id;
 
     public:
-        const std::string get_lcl()
+        const p2p::sequence_hash get_lcl_id()
         {
             std::shared_lock lock(lcl_mutex);
-            return lcl;
+            return lcl_id;
         }
 
-        uint64_t get_seq_no()
-        {
-            std::shared_lock lock(lcl_mutex);
-            return seq_no;
-        }
-
-        void set_lcl(const uint64_t new_seq_no, std::string_view new_lcl)
+        void set_lcl_id(const p2p::sequence_hash &sequence_hash_id)
         {
             std::unique_lock lock(lcl_mutex);
-            lcl = new_lcl;
-            seq_no = new_seq_no;
+            lcl_id = sequence_hash_id;
         }
 
         const p2p::sequence_hash get_last_primary_shard_id()
@@ -74,7 +65,7 @@ namespace ledger
 
     struct ledger_blob
     {
-        std::string ledger_hash;
+        util::h32 ledger_hash;
         std::map<std::string, std::vector<std::string>> inputs;
         std::map<std::string, std::vector<std::string>> outputs;
     };
@@ -97,11 +88,11 @@ namespace ledger
 
     void remove_old_shards(const uint64_t led_shard_no, std::string_view shard_parent_dir);
 
-    int extract_lcl(const std::string &lcl, uint64_t &seq_no, std::string &hash);
-
     int get_last_ledger_and_update_context();
 
     int get_last_shard_info(std::string_view session_name, p2p::sequence_hash &last_shard_id, std::string_view shard_parent_dir);
+
+    const std::string get_lcl_string(const p2p::sequence_hash &lcl_id);
 
 } // namespace ledger
 

--- a/src/msg/fbuf/ledger_helpers.cpp
+++ b/src/msg/fbuf/ledger_helpers.cpp
@@ -8,45 +8,6 @@
 namespace msg::fbuf::ledgermsg
 {
     /**
-     * Create ledger block from the given proposal struct.
-     * @param p The proposal struct to be placed in ledger.
-     */
-    void create_ledger_block_from_proposal(flatbuffers::FlatBufferBuilder &builder, const p2p::proposal &p, const uint64_t seq_no)
-    {
-        flatbuffers::Offset<ledgermsg::LedgerBlock> ledger =
-            ledgermsg::CreateLedgerBlock(
-                builder,
-                sv_to_flatbuff_str(builder, conf::cfg.hp_version),
-                seq_no,
-                p.time,
-                sv_to_flatbuff_bytes(builder, p.lcl),
-                hash_to_flatbuff_bytes(builder, p.state_hash),
-                hash_to_flatbuff_bytes(builder, p.patch_hash),
-                stringlist_to_flatbuf_bytearrayvector(builder, p.users),
-                stringlist_to_flatbuf_bytearrayvector(builder, p.input_hashes),
-                sv_to_flatbuff_bytes(builder, p.output_hash));
-
-        builder.Finish(ledger); // Finished building message content to get serialised content.
-    }
-
-    p2p::proposal create_proposal_from_ledger_block(const std::vector<uint8_t> &ledger_buf)
-    {
-        auto ledger = msg::fbuf::ledgermsg::GetLedgerBlock(ledger_buf.data());
-        p2p::proposal p;
-        p.lcl = flatbuff_bytes_to_sv(ledger->lcl());
-        p.state_hash = flatbuff_bytes_to_hash(ledger->state_hash());
-        p.patch_hash = flatbuff_bytes_to_hash(ledger->patch_hash());
-        // We do not need to convert all the fields of the proposal due to them not being used for any ledger-specific logic.
-        return p;
-    }
-
-    bool verify_ledger_block_buffer(const uint8_t *ledger_buf_ptr, const size_t buf_len)
-    {
-        flatbuffers::Verifier ledger_verifier(ledger_buf_ptr, buf_len);
-        return VerifyLedgerBlockBuffer(ledger_verifier);
-    }
-
-    /**
      * Create ledger blob msg from ledger blob struct.
      * @param ledger_blob Ledger blob to be placed in file.
      */
@@ -88,7 +49,7 @@ namespace msg::fbuf::ledgermsg
         flatbuffers::Offset<ledgermsg::LedgerBlob> blob =
             ledgermsg::CreateLedgerBlob(
                 builder,
-                sv_to_flatbuff_bytes(builder, ledger_blob.ledger_hash),
+                hash_to_flatbuff_bytes(builder, ledger_blob.ledger_hash),
                 builder.CreateVector(raw_inputs),
                 builder.CreateVector(raw_outputs));
 

--- a/src/msg/fbuf/ledger_helpers.hpp
+++ b/src/msg/fbuf/ledger_helpers.hpp
@@ -9,12 +9,6 @@
 namespace msg::fbuf::ledgermsg
 {
 
-    void create_ledger_block_from_proposal(flatbuffers::FlatBufferBuilder &builder, const p2p::proposal &p, const uint64_t seq_no);
-
-    p2p::proposal create_proposal_from_ledger_block(const std::vector<uint8_t> &ledger_buf);
-
-    bool verify_ledger_block_buffer(const uint8_t *ledger_buf_ptr, const size_t buf_len);
-
     void create_ledger_blob_msg_from_ledger_blob(flatbuffers::FlatBufferBuilder &builder, const ledger::ledger_blob &ledger_blob);
 
 } // namespace msg::fbuf::ledgermsg

--- a/src/msg/fbuf/p2pmsg_helpers.cpp
+++ b/src/msg/fbuf/p2pmsg_helpers.cpp
@@ -199,7 +199,7 @@ namespace msg::fbuf::p2pmsg
  * @param msg The Flatbuffer poposal received from the peer.
  * @return A proposal struct representing the message.
  */
-    const p2p::proposal create_proposal_from_msg(const Proposal_Message &msg, const flatbuffers::Vector<uint8_t> *pubkey, const uint64_t timestamp, const flatbuffers::Vector<uint8_t> *lcl, const Sequence_Hash &last_primary_shard_id_msg)
+    const p2p::proposal create_proposal_from_msg(const Proposal_Message &msg, const flatbuffers::Vector<uint8_t> *pubkey, const uint64_t timestamp, const Sequence_Hash &last_primary_shard_id_msg)
     {
         p2p::proposal p;
 
@@ -210,7 +210,6 @@ namespace msg::fbuf::p2pmsg
         p.roundtime = msg.roundtime();
         p.nonce = flatbuff_bytes_to_sv(msg.nonce());
         p.stage = msg.stage();
-        p.lcl = flatbuff_bytes_to_sv(lcl);
         p.state_hash = flatbuff_bytes_to_sv(msg.state_hash());
         p.patch_hash = flatbuff_bytes_to_sv(msg.patch_hash());
 
@@ -294,7 +293,7 @@ namespace msg::fbuf::p2pmsg
         builder.Finish(message); // Finished building message content to get serialised content.
 
         // Now that we have built the content message
-        create_containermsg_from_content(container_builder, builder, {}, {}, false);
+        create_containermsg_from_content(container_builder, builder, {}, false);
     }
 
     /**
@@ -317,7 +316,7 @@ namespace msg::fbuf::p2pmsg
 
         // Now that we have built the content message,
         // we need to sign it and place it inside a container message.
-        create_containermsg_from_content(container_builder, builder, {}, {}, true);
+        create_containermsg_from_content(container_builder, builder, {}, true);
     }
 
     void create_msg_from_nonunl_proposal(flatbuffers::FlatBufferBuilder &container_builder, const p2p::nonunl_proposal &nup)
@@ -334,7 +333,7 @@ namespace msg::fbuf::p2pmsg
 
         // Now that we have built the content message,
         // we need to sign it and place it inside a container message.
-        create_containermsg_from_content(container_builder, builder, {}, {}, false);
+        create_containermsg_from_content(container_builder, builder, {}, false);
     }
 
     /**
@@ -372,17 +371,16 @@ namespace msg::fbuf::p2pmsg
 
         // Now that we have built the content message,
         // we need to sign it and place it inside a container message.
-        create_containermsg_from_content(container_builder, builder, p.lcl, p.last_primary_shard_id, true);
+        create_containermsg_from_content(container_builder, builder, p.last_primary_shard_id, true);
     }
 
     /**
      * Ctreat npl message from the given npl output srtuct.
      * @param container_builder Flatbuffer builder for the container message.
      * @param msg The message to be sent as NPL message.
-     * @param lcl Lcl value to be passed in the container message.
      * @param last_primary_shard_id Last primary shard id.
      */
-    void create_msg_from_npl_output(flatbuffers::FlatBufferBuilder &container_builder, const std::string_view &msg, std::string_view lcl, const p2p::sequence_hash &last_primary_shard_id)
+    void create_msg_from_npl_output(flatbuffers::FlatBufferBuilder &container_builder, const std::string_view &msg, const p2p::sequence_hash &last_primary_shard_id)
     {
         flatbuffers::FlatBufferBuilder builder(1024);
 
@@ -396,17 +394,16 @@ namespace msg::fbuf::p2pmsg
 
         // Now that we have built the content message,
         // we need to sign it and place it inside a container message.
-        create_containermsg_from_content(container_builder, builder, lcl, last_primary_shard_id, true);
+        create_containermsg_from_content(container_builder, builder, last_primary_shard_id, true);
     }
 
     /**
      * Create hpfs request message from the given hpfs request struct.
      * @param container_builder Flatbuffer builder for the container message.
      * @param hr The hpfs request struct to be placed in the container message.
-     * @param lcl Lcl to be include in the container msg.
      * @param last_primary_shard_id Last primary shard id.
      */
-    void create_msg_from_hpfs_request(flatbuffers::FlatBufferBuilder &container_builder, const p2p::hpfs_request &hr, std::string_view lcl, const p2p::sequence_hash &last_primary_shard_id)
+    void create_msg_from_hpfs_request(flatbuffers::FlatBufferBuilder &container_builder, const p2p::hpfs_request &hr, const p2p::sequence_hash &last_primary_shard_id)
     {
         flatbuffers::FlatBufferBuilder builder(1024);
 
@@ -424,7 +421,7 @@ namespace msg::fbuf::p2pmsg
 
         // Now that we have built the content message,
         // we need to sign it and place it inside a container message.
-        create_containermsg_from_content(container_builder, builder, lcl, last_primary_shard_id, false);
+        create_containermsg_from_content(container_builder, builder, last_primary_shard_id, false);
     }
 
     /**
@@ -434,12 +431,11 @@ namespace msg::fbuf::p2pmsg
      * @param mount_id The mount id of the relavent hpfs mount.
      * @param hash_nodes File or directory entries with hashes in the given parent path.
      * @param expected_hash The exptected hash of the requested path.
-     * @param lcl Lcl to be include in the container msg.
      * @param last_primary_shard_id Last primary shard id.
      */
     void create_msg_from_fsentry_response(
         flatbuffers::FlatBufferBuilder &container_builder, const std::string_view path, const uint32_t mount_id,
-        std::vector<hpfs::child_hash_node> &hash_nodes, util::h32 expected_hash, std::string_view lcl, const p2p::sequence_hash &last_primary_shard_id)
+        std::vector<hpfs::child_hash_node> &hash_nodes, util::h32 expected_hash, const p2p::sequence_hash &last_primary_shard_id)
     {
         flatbuffers::FlatBufferBuilder builder(1024);
 
@@ -459,7 +455,7 @@ namespace msg::fbuf::p2pmsg
 
         // Now that we have built the content message,
         // we need to sign it and place it inside a container message.
-        create_containermsg_from_content(container_builder, builder, lcl, last_primary_shard_id, true);
+        create_containermsg_from_content(container_builder, builder, last_primary_shard_id, true);
     }
 
     /**
@@ -468,12 +464,11 @@ namespace msg::fbuf::p2pmsg
      * @param path The path of the directory.
      * @param mount_id The mount id of the relavent hpfs mount.
      * @param hashmap Hashmap of the file
-     * @param lcl Lcl to be include in the container msg.
      * @param last_primary_shard_id Last primary shard id.
      */
     void create_msg_from_filehashmap_response(
         flatbuffers::FlatBufferBuilder &container_builder, std::string_view path, const uint32_t mount_id,
-        std::vector<util::h32> &hashmap, std::size_t file_length, util::h32 expected_hash, std::string_view lcl, const p2p::sequence_hash &last_primary_shard_id)
+        std::vector<util::h32> &hashmap, std::size_t file_length, util::h32 expected_hash, const p2p::sequence_hash &last_primary_shard_id)
     {
         // todo:get a average propsal message size and allocate content builder based on that.
         flatbuffers::FlatBufferBuilder builder(1024);
@@ -498,7 +493,7 @@ namespace msg::fbuf::p2pmsg
 
         // Now that we have built the content message,
         // we need to sign it and place it inside a container message.
-        create_containermsg_from_content(container_builder, builder, lcl, last_primary_shard_id, true);
+        create_containermsg_from_content(container_builder, builder, last_primary_shard_id, true);
     }
 
     /**
@@ -506,11 +501,10 @@ namespace msg::fbuf::p2pmsg
      * @param container_builder Flatbuffer builder for the container message.
      * @param block_resp Block response struct to place in the message.
      * @param mount_id The mount id of the relavent hpfs mount.
-     * @param lcl Lcl to be include in the container message.
      * @param last_primary_shard_id Last primary shard id.
      */
     void create_msg_from_block_response(flatbuffers::FlatBufferBuilder &container_builder, p2p::block_response &block_resp, const uint32_t mount_id,
-                                        std::string_view lcl, const p2p::sequence_hash &last_primary_shard_id)
+                                        const p2p::sequence_hash &last_primary_shard_id)
     {
         // todo:get a average propsal message size and allocate content builder based on that.
         flatbuffers::FlatBufferBuilder builder(1024);
@@ -533,17 +527,16 @@ namespace msg::fbuf::p2pmsg
 
         // Now that we have built the content message,
         // we need to sign it and place it inside a container message.
-        create_containermsg_from_content(container_builder, builder, lcl, last_primary_shard_id, true);
+        create_containermsg_from_content(container_builder, builder, last_primary_shard_id, true);
     }
 
     /**
      * Create connected status announcement message.
      * @param container_builder Flatbuffer builder for the container message.
      * @param need_consensus_msg_forwarding True if number of connections are below threshold and false otherwise.
-     * @param lcl Lcl value to be passed in the container message.
      */
     void create_msg_from_peer_requirement_announcement(flatbuffers::FlatBufferBuilder &container_builder, const bool need_consensus_msg_forwarding,
-                                                       std::string_view lcl, const p2p::sequence_hash &last_primary_shard_id)
+                                                       const p2p::sequence_hash &last_primary_shard_id)
     {
         flatbuffers::FlatBufferBuilder builder(1024);
 
@@ -556,7 +549,7 @@ namespace msg::fbuf::p2pmsg
         builder.Finish(message); // Finished building message content to get serialised content.
 
         // Now that we have built the content message,
-        create_containermsg_from_content(container_builder, builder, lcl, last_primary_shard_id, false);
+        create_containermsg_from_content(container_builder, builder, last_primary_shard_id, false);
     }
 
     /**
@@ -564,10 +557,9 @@ namespace msg::fbuf::p2pmsg
      * @param container_builder Flatbuffer builder for the container message.
      * @param available_capacity Number of incoming connection slots available, -1 means there's no limitation for connections.
      * @param timestamp Announced timestamp.
-     * @param lcl Lcl value to be passed in the container message.
      */
     void create_msg_from_available_capacity_announcement(flatbuffers::FlatBufferBuilder &container_builder, const int16_t &available_capacity, const uint64_t &timestamp,
-                                                         std::string_view lcl, const p2p::sequence_hash &last_primary_shard_id)
+                                                         const p2p::sequence_hash &last_primary_shard_id)
     {
         flatbuffers::FlatBufferBuilder builder(1024);
 
@@ -581,15 +573,14 @@ namespace msg::fbuf::p2pmsg
         builder.Finish(message); // Finished building message content to get serialised content.
 
         // Now that we have built the content message,
-        create_containermsg_from_content(container_builder, builder, lcl, last_primary_shard_id, false);
+        create_containermsg_from_content(container_builder, builder, last_primary_shard_id, false);
     }
 
     /**
      * Create peer list request message.
      * @param container_builder Flatbuffer builder for the container message.
-     * @param lcl Lcl value to be passed in the container message.
      */
-    void create_msg_from_peer_list_request(flatbuffers::FlatBufferBuilder &container_builder, std::string_view lcl, const p2p::sequence_hash &last_primary_shard_id)
+    void create_msg_from_peer_list_request(flatbuffers::FlatBufferBuilder &container_builder, const p2p::sequence_hash &last_primary_shard_id)
     {
         flatbuffers::FlatBufferBuilder builder(1024);
 
@@ -601,7 +592,7 @@ namespace msg::fbuf::p2pmsg
         builder.Finish(message); // Finished building message content to get serialised content.
 
         // Now that we have built the content message,
-        create_containermsg_from_content(container_builder, builder, lcl, last_primary_shard_id, false);
+        create_containermsg_from_content(container_builder, builder, last_primary_shard_id, false);
     }
 
     /**
@@ -609,10 +600,9 @@ namespace msg::fbuf::p2pmsg
      * @param container_builder Flatbuffer builder for the container message.
      * @param peers Peer list to be sent to another peer.
      * @param skipping_peer Peer that does not need to be sent.
-     * @param lcl Lcl value to be passed in the container message.
      */
     void create_msg_from_peer_list_response(flatbuffers::FlatBufferBuilder &container_builder, const std::vector<conf::peer_properties> &peers, const std::optional<conf::peer_ip_port> &skipping_ip_port,
-                                            std::string_view lcl, const p2p::sequence_hash &last_primary_shard_id)
+                                            const p2p::sequence_hash &last_primary_shard_id)
     {
         flatbuffers::FlatBufferBuilder builder(1024);
 
@@ -625,7 +615,7 @@ namespace msg::fbuf::p2pmsg
         builder.Finish(message); // Finished building message content to get serialised content.
 
         // Now that we have built the content message,
-        create_containermsg_from_content(container_builder, builder, lcl, last_primary_shard_id, false);
+        create_containermsg_from_content(container_builder, builder, last_primary_shard_id, false);
     }
 
     /**
@@ -636,7 +626,7 @@ namespace msg::fbuf::p2pmsg
      * @param sign Whether to sign the message content.
      */
     void create_containermsg_from_content(
-        flatbuffers::FlatBufferBuilder &container_builder, const flatbuffers::FlatBufferBuilder &content_builder, std::string_view lcl, const p2p::sequence_hash &last_primary_shard_id, const bool sign)
+        flatbuffers::FlatBufferBuilder &container_builder, const flatbuffers::FlatBufferBuilder &content_builder, const p2p::sequence_hash &last_primary_shard_id, const bool sign)
     {
         const uint8_t *content_buf = content_builder.GetBufferPointer();
         const flatbuffers::uoffset_t content_size = content_builder.GetSize();
@@ -647,8 +637,6 @@ namespace msg::fbuf::p2pmsg
         flatbuffers::Offset<flatbuffers::Vector<uint8_t>> pubkey_offset = 0;
         flatbuffers::Offset<flatbuffers::Vector<uint8_t>> sig_offset = 0;
 
-        flatbuffers::Offset<flatbuffers::Vector<uint8_t>> lcl_offset = 0;
-
         if (sign)
         {
             // Sign message content with this node's private key.
@@ -657,9 +645,6 @@ namespace msg::fbuf::p2pmsg
             sig_offset = sv_to_flatbuff_bytes(container_builder, crypto::sign(content_to_sign, conf::cfg.node.private_key));
             pubkey_offset = sv_to_flatbuff_bytes(container_builder, conf::cfg.node.public_key);
         }
-
-        if (!lcl.empty())
-            lcl_offset = sv_to_flatbuff_bytes(container_builder, lcl);
 
         const flatbuffers::Offset<Sequence_Hash> last_primary_shard_id_msg = CreateSequence_Hash(
             container_builder,
@@ -671,7 +656,7 @@ namespace msg::fbuf::p2pmsg
             util::PEERMSG_VERSION,
             util::get_epoch_milliseconds(),
             pubkey_offset,
-            lcl_offset,
+            0,
             last_primary_shard_id_msg,
             sig_offset,
             content);

--- a/src/msg/fbuf/p2pmsg_helpers.hpp
+++ b/src/msg/fbuf/p2pmsg_helpers.hpp
@@ -30,7 +30,7 @@ namespace msg::fbuf::p2pmsg
 
     const p2p::nonunl_proposal create_nonunl_proposal_from_msg(const NonUnl_Proposal_Message &msg, const uint64_t timestamp);
 
-    const p2p::proposal create_proposal_from_msg(const Proposal_Message &msg, const flatbuffers::Vector<uint8_t> *pubkey, const uint64_t timestamp, const flatbuffers::Vector<uint8_t> *lcl, const Sequence_Hash &last_primary_shard_id_msg);
+    const p2p::proposal create_proposal_from_msg(const Proposal_Message &msg, const flatbuffers::Vector<uint8_t> *pubkey, const uint64_t timestamp, const Sequence_Hash &last_primary_shard_id_msg);
 
     const p2p::hpfs_request create_hpfs_request_from_msg(const Hpfs_Request_Message &msg);
 
@@ -45,34 +45,34 @@ namespace msg::fbuf::p2pmsg
 
     void create_msg_from_proposal(flatbuffers::FlatBufferBuilder &container_builder, const p2p::proposal &p);
 
-    void create_msg_from_npl_output(flatbuffers::FlatBufferBuilder &container_builder, const std::string_view &msg, std::string_view lcl, const p2p::sequence_hash &last_primary_shard_id);
+    void create_msg_from_npl_output(flatbuffers::FlatBufferBuilder &container_builder, const std::string_view &msg, const p2p::sequence_hash &last_primary_shard_id);
 
-    void create_msg_from_hpfs_request(flatbuffers::FlatBufferBuilder &container_builder, const p2p::hpfs_request &hr, std::string_view lcl, const p2p::sequence_hash &last_primary_shard_id);
+    void create_msg_from_hpfs_request(flatbuffers::FlatBufferBuilder &container_builder, const p2p::hpfs_request &hr, const p2p::sequence_hash &last_primary_shard_id);
 
     void create_msg_from_fsentry_response(
         flatbuffers::FlatBufferBuilder &container_builder, const std::string_view path, const uint32_t mount_id,
-        std::vector<hpfs::child_hash_node> &hash_nodes, util::h32 expected_hash, std::string_view lcl, const p2p::sequence_hash &last_primary_shard_id);
+        std::vector<hpfs::child_hash_node> &hash_nodes, util::h32 expected_hash, const p2p::sequence_hash &last_primary_shard_id);
 
     void create_msg_from_filehashmap_response(
         flatbuffers::FlatBufferBuilder &container_builder, std::string_view path, const uint32_t mount_id,
-        std::vector<util::h32> &hashmap, std::size_t file_length, util::h32 expected_hash, std::string_view lcl, const p2p::sequence_hash &last_primary_shard_id);
+        std::vector<util::h32> &hashmap, std::size_t file_length, util::h32 expected_hash, const p2p::sequence_hash &last_primary_shard_id);
 
     void create_msg_from_block_response(flatbuffers::FlatBufferBuilder &container_builder, p2p::block_response &block_resp, const uint32_t mount_id,
-                                        std::string_view lcl, const p2p::sequence_hash &last_primary_shard_id);
+                                        const p2p::sequence_hash &last_primary_shard_id);
 
     void create_containermsg_from_content(
-        flatbuffers::FlatBufferBuilder &container_builder, const flatbuffers::FlatBufferBuilder &content_builder, std::string_view lcl, const p2p::sequence_hash &last_primary_shard_id, const bool sign);
+        flatbuffers::FlatBufferBuilder &container_builder, const flatbuffers::FlatBufferBuilder &content_builder, const p2p::sequence_hash &last_primary_shard_id, const bool sign);
 
     void create_msg_from_peer_requirement_announcement(flatbuffers::FlatBufferBuilder &container_builder, const bool need_consensus_msg_forwarding,
-                                                       std::string_view lcl, const p2p::sequence_hash &last_primary_shard_id);
+                                                       const p2p::sequence_hash &last_primary_shard_id);
 
     void create_msg_from_available_capacity_announcement(flatbuffers::FlatBufferBuilder &container_builder, const int16_t &available_capacity, const uint64_t &timestamp,
-                                                         std::string_view lcl, const p2p::sequence_hash &last_primary_shard_id);
+                                                         const p2p::sequence_hash &last_primary_shard_id);
 
-    void create_msg_from_peer_list_request(flatbuffers::FlatBufferBuilder &container_builder, std::string_view lcl, const p2p::sequence_hash &last_primary_shard_id);
+    void create_msg_from_peer_list_request(flatbuffers::FlatBufferBuilder &container_builder, const p2p::sequence_hash &last_primary_shard_id);
 
     void create_msg_from_peer_list_response(flatbuffers::FlatBufferBuilder &container_builder, const std::vector<conf::peer_properties> &peers, const std::optional<conf::peer_ip_port> &skipping_ip_port,
-                                            std::string_view lcl, const p2p::sequence_hash &last_primary_shard_id);
+                                            const p2p::sequence_hash &last_primary_shard_id);
 
     //---Conversion helpers from flatbuffers data types to std data types---//
 

--- a/src/p2p/p2p.cpp
+++ b/src/p2p/p2p.cpp
@@ -289,7 +289,7 @@ namespace p2p
     void send_peer_requirement_announcement(const bool need_consensus_msg_forwarding, peer_comm_session *session)
     {
         flatbuffers::FlatBufferBuilder fbuf(1024);
-        msg::fbuf::p2pmsg::create_msg_from_peer_requirement_announcement(fbuf, need_consensus_msg_forwarding, ledger::ctx.get_lcl(), ledger::ctx.get_last_primary_shard_id());
+        msg::fbuf::p2pmsg::create_msg_from_peer_requirement_announcement(fbuf, need_consensus_msg_forwarding, ledger::ctx.get_last_primary_shard_id());
         if (session)
         {
             std::string_view msg = std::string_view(
@@ -310,7 +310,7 @@ namespace p2p
     {
         const uint64_t time_now = util::get_epoch_milliseconds();
         flatbuffers::FlatBufferBuilder fbuf(1024);
-        msg::fbuf::p2pmsg::create_msg_from_available_capacity_announcement(fbuf, available_capacity, time_now, ledger::ctx.get_lcl(), ledger::ctx.get_last_primary_shard_id());
+        msg::fbuf::p2pmsg::create_msg_from_available_capacity_announcement(fbuf, available_capacity, time_now, ledger::ctx.get_last_primary_shard_id());
         broadcast_message(fbuf, false);
     }
 
@@ -321,7 +321,7 @@ namespace p2p
     void send_known_peer_list(peer_comm_session *session)
     {
         flatbuffers::FlatBufferBuilder fbuf(1024);
-        msg::fbuf::p2pmsg::create_msg_from_peer_list_response(fbuf, ctx.server->req_known_remotes, session->known_ipport, ledger::ctx.get_lcl(), ledger::ctx.get_last_primary_shard_id());
+        msg::fbuf::p2pmsg::create_msg_from_peer_list_response(fbuf, ctx.server->req_known_remotes, session->known_ipport, ledger::ctx.get_last_primary_shard_id());
         std::string_view msg = std::string_view(
             reinterpret_cast<const char *>(fbuf.GetBufferPointer()), fbuf.GetSize());
         session->send(msg);
@@ -355,7 +355,7 @@ namespace p2p
     void send_peer_list_request()
     {
         flatbuffers::FlatBufferBuilder fbuf(1024);
-        msg::fbuf::p2pmsg::create_msg_from_peer_list_request(fbuf, ledger::ctx.get_lcl(), ledger::ctx.get_last_primary_shard_id());
+        msg::fbuf::p2pmsg::create_msg_from_peer_list_request(fbuf, ledger::ctx.get_last_primary_shard_id());
         std::string target_pubkey;
         send_message_to_random_peer(fbuf, target_pubkey);
         LOG_DEBUG << "Peer list request: Requesting from [" << target_pubkey.substr(0, 10) << "]";

--- a/src/p2p/p2p.hpp
+++ b/src/p2p/p2p.hpp
@@ -51,7 +51,6 @@ namespace p2p
         uint8_t stage = 0;           // The round-stage that this proposal belongs to.
         uint32_t roundtime = 0;      // Roundtime of the proposer.
         std::string nonce;           // Random nonce that is used to reduce lcl predictability.
-        std::string lcl;
         sequence_hash last_primary_shard_id;
         sequence_hash last_blob_shard_id;
         util::h32 state_hash; // Contract state hash.
@@ -91,8 +90,8 @@ namespace p2p
     // Represents an NPL message sent by a peer.
     struct npl_message
     {
-        std::string pubkey; // Peer binary pubkey.
-        std::string lcl;    // LCL of the peer.
+        std::string pubkey;                       // Peer binary pubkey.
+        p2p::sequence_hash last_primary_shard_id; // Last primary shard of the peer.
         std::string data;
     };
 

--- a/src/p2p/peer_session_handler.cpp
+++ b/src/p2p/peer_session_handler.cpp
@@ -324,7 +324,7 @@ namespace p2p
             return -1;
 
         ctx.collected_msgs.proposals.push_back(
-            p2pmsg::create_proposal_from_msg(*content->message_as_Proposal_Message(), container->pubkey(), container->timestamp(), container->lcl(), *container->last_primary_shard_id()));
+            p2pmsg::create_proposal_from_msg(*content->message_as_Proposal_Message(), container->pubkey(), container->timestamp(), *container->last_primary_shard_id()));
 
         return 0;
     }
@@ -356,7 +356,8 @@ namespace p2p
         npl_message msg;
         msg.data = msg::fbuf::flatbuff_bytes_to_sv(npl_p2p_msg->data());
         msg.pubkey = msg::fbuf::flatbuff_bytes_to_sv(container->pubkey());
-        msg.lcl = msg::fbuf::flatbuff_bytes_to_sv(container->lcl());
+        msg.last_primary_shard_id.seq_no = container->last_primary_shard_id()->shard_seq_no();
+        msg.last_primary_shard_id.hash = msg::fbuf::flatbuff_bytes_to_hash(container->last_primary_shard_id()->shard_hash());
 
         if (!consensus::push_npl_message(msg))
         {

--- a/src/sc/sc.cpp
+++ b/src/sc/sc.cpp
@@ -474,11 +474,11 @@ namespace sc
             return 0;
 
         // Dequeue the next npl message from the queue.
-        // Check the lcl against the latest lcl.
+        // Check the last pramary shard against the latest last pramary shard.
         p2p::npl_message npl_msg;
         if (ctx.args.npl_messages.try_dequeue(npl_msg))
         {
-            if (npl_msg.lcl == ctx.args.lcl)
+            if (npl_msg.last_primary_shard_id == ctx.args.lasl_primary_shard_id)
             {
                 const std::string pubkeyhex = util::to_hex(npl_msg.pubkey);
 
@@ -500,7 +500,7 @@ namespace sc
             }
             else
             {
-                LOG_DEBUG << "NPL message dropped due to lcl mismatch.";
+                LOG_DEBUG << "NPL message dropped due to last primary shard mismatch.";
             }
         }
 
@@ -576,7 +576,7 @@ namespace sc
         if (!output.empty())
         {
             flatbuffers::FlatBufferBuilder fbuf(1024);
-            msg::fbuf::p2pmsg::create_msg_from_npl_output(fbuf, output, ledger::ctx.get_lcl(), ledger::ctx.get_last_primary_shard_id());
+            msg::fbuf::p2pmsg::create_msg_from_npl_output(fbuf, output, ledger::ctx.get_last_primary_shard_id());
             p2p::broadcast_message(fbuf, true, false, !conf::cfg.contract.is_npl_public);
         }
     }

--- a/src/sc/sc.hpp
+++ b/src/sc/sc.hpp
@@ -85,6 +85,9 @@ namespace sc
         // Current HotPocket lcl (seq no. and ledger hash hex)
         std::string lcl;
 
+        // Current HotPocket primary shard id (struct of seq no. and ledger hash)
+        p2p::sequence_hash lasl_primary_shard_id;
+
         // State hash after execution will be copied to this (not applicable to read only mode).
         util::h32 post_execution_state_hash = util::h32_empty;
 

--- a/src/usr/input_nonce_map.cpp
+++ b/src/usr/input_nonce_map.cpp
@@ -33,7 +33,7 @@ namespace usr
             const uint64_t expire_lcl_seqno = std::get<2>(itr->second);
 
             // Check if previous nonce has already expired or it is less than new nonce.
-            if (expire_lcl_seqno <= ledger::ctx.get_seq_no() || existing_nonce < nonce)
+            if (expire_lcl_seqno <= ledger::ctx.get_lcl_id().seq_no || existing_nonce < nonce)
             {
                 if (!no_add)
                 {

--- a/src/usr/usr.cpp
+++ b/src/usr/usr.cpp
@@ -227,7 +227,8 @@ namespace usr
             else if (msg_type == msg::usrmsg::MSGTYPE_STAT)
             {
                 std::vector<uint8_t> msg;
-                parser.create_status_response(msg, ledger::ctx.get_seq_no(), ledger::ctx.get_lcl());
+                const p2p::sequence_hash lcl_id = ledger::ctx.get_lcl_id();
+                parser.create_status_response(msg, lcl_id.seq_no, ledger::get_lcl_string(lcl_id));
                 user.session.send(msg);
                 return 0;
             }


### PR DESCRIPTION
- Removed lcl param from flatbuf helper methods.
- Removed lcl from proposal.
- Updated npl expiration check last primary shard id instead of lcl.
- Send constructed lcl (seq_no-lcl_hash_hex) only to contract and users.