### PR TITLE
Changed the validation for max_connections and max_known_connections when reading the cfg

### DIFF
--- a/src/conf.cpp
+++ b/src/conf.cpp
@@ -425,7 +425,7 @@ namespace conf
                 cfg.mesh.max_connections = mesh["max_connections"].as<uint16_t>();
                 cfg.mesh.max_known_connections = mesh["max_known_connections"].as<uint16_t>();
                 cfg.mesh.max_in_connections_per_host = mesh["max_in_connections_per_host"].as<uint16_t>();
-                // If a value is given for max_connections then max_known_connections value should not be 0(unlimited) and it should be less or equal than max_connections.
+                // If a value is specified for max_connections then max_known_connections value should not be 0(unlimited) and it should be less or equal than max_connections.
                 if (cfg.mesh.max_connections > 0 && (cfg.mesh.max_known_connections > cfg.mesh.max_connections || cfg.mesh.max_known_connections == 0))
                 {
                     std::cerr << "Invalid configuration values: mesh max_known_connections count should not exceed mesh max_connections." << '\n';


### PR DESCRIPTION
- If a value is given for max_connections then max_known_connections value should not be 0 (unlimited) and it should be less or equal than that value.