### PR TITLE
Resetting last shard syncing flags when sync is abandoned.

### DIFF
--- a/src/ledger/ledger_sync.cpp
+++ b/src/ledger/ledger_sync.cpp
@@ -157,4 +157,11 @@ namespace ledger
             candidate_hpfs_responses.splice(candidate_hpfs_responses.end(), p2p::ctx.collected_msgs.ledger_hpfs_responses);
     }
 
+    void ledger_sync::on_sync_abandoned()
+    {
+        // Reset these flags since we are abandoning the sync.
+        is_last_primary_shard_syncing = false;
+        is_last_blob_shard_syncing = false;
+    }
+
 } // namespace ledger

--- a/src/ledger/ledger_sync.hpp
+++ b/src/ledger/ledger_sync.hpp
@@ -13,6 +13,7 @@ namespace ledger
     private:
         void swap_collected_responses();
         void on_current_sync_state_acheived(const hpfs::sync_target &synced_target);
+        void on_sync_abandoned();
 
     public:
         std::atomic<bool> is_last_primary_shard_syncing = false;


### PR DESCRIPTION
Fixing not switching back to validator once the sync is abandoned.

- Reset is_last_primary_shard_syncing and is_last_blob_shard_syncing flags when sync is abandoned.