### PR TITLE
Include failed server name and port number (Peer/user) in hpws server creation fail error

### DIFF
--- a/src/comm/comm_server.hpp
+++ b/src/comm/comm_server.hpp
@@ -206,10 +206,7 @@ namespace comm
             if (std::holds_alternative<hpws::error>(result))
             {
                 const hpws::error e = std::get<hpws::error>(result);
-                // Convert first letter to lowercase.
-                std::string name_lowercase = name;
-                name_lowercase[0] = std::tolower(name_lowercase[0]);
-                LOG_ERROR << "Error creating " << name_lowercase << " hpws server:" << e.first << " " << e.second << " Port: " << std::to_string(listen_port);
+                LOG_ERROR << name << " hpws server creation failed. " << e.first << " " << e.second << " Port: " << std::to_string(listen_port);
                 return -1;
             }
 


### PR DESCRIPTION
Added server name and port number to port binding failed error message when the user and peer servers are started.