### PR TITLE
C contract library changes.

### DIFF
--- a/examples/c_contract/hotpocket_contract.h
+++ b/examples/c_contract/hotpocket_contract.h
@@ -10,6 +10,7 @@
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include "json.h"
+#include <fcntl.h>
 
 // Private constants.
 #define __HP_MMAP_BLOCK_SIZE 4096
@@ -547,7 +548,7 @@ int hp_update_config(const struct hp_config *config)
  */
 void hp_set_config_string(char **config_str, const char *value, const size_t value_size)
 {
-    *config_str = realloc(*config_str, value_size);
+    *config_str = (char *)realloc(*config_str, value_size);
     strncpy(*config_str, value, value_size);
 }
 
@@ -560,7 +561,7 @@ void hp_set_config_string(char **config_str, const char *value, const size_t val
 void hp_set_config_unl(struct hp_config *config, const struct hp_unl_node *new_unl, const size_t new_unl_count)
 {
     const size_t mem_size = sizeof(struct hp_unl_node) * new_unl_count;
-    config->unl.list = realloc(config->unl.list, mem_size);
+    config->unl.list = (struct hp_unl_node *)realloc(config->unl.list, mem_size);
     memcpy(config->unl.list, new_unl, mem_size);
     config->unl.count = new_unl_count;
 }


### PR DESCRIPTION
- Added the missing return 0 in hotpocket_contract.h,  hp_deinit_contract() method.
- Added a library (fcntl.h) to suppress error when building with g++.
- Added missing pointer castings.