### PR TITLE
Increasing event batch size in stream.js

### DIFF
--- a/examples/js_client/package.json
+++ b/examples/js_client/package.json
@@ -1,6 +1,6 @@
 {
     "scripts": {
-        "merge-browser": "rm -r dist ; mkdir -p dist && cp lib/bson-browser.js dist/hp-client-lib.js && cat lib/hp-client-lib.js >> dist/hp-client-lib.js",
+        "merge-browser": "rm -f -r dist ; mkdir -p dist && cp lib/bson-browser.js dist/hp-client-lib.js && cat lib/hp-client-lib.js >> dist/hp-client-lib.js",
         "minify-browser": "terser --compress --mangle reserved=['Binary','Buffer'] -- dist/hp-client-lib.js > dist/hp-client-lib.min.js && rm dist/hp-client-lib.js",
         "build-browser": "npm run merge-browser && npm run minify-browser",
         "build-nodejs": "ncc build lib/hp-client-lib.js -o dist/hp-client"

--- a/test/vm-cluster/stream.js
+++ b/test/vm-cluster/stream.js
@@ -8,7 +8,7 @@ const dispatchInterval = process.env.DISPATCH || 1000;
 const stateUploadInterval = process.env.STATEUPLOAD || 10000;
 const metricsTrackInterval = process.env.METRICSTRACK || 10000;
 const backoffDelayMax = process.env.BACKOFFMAX || 60000;
-const eventsBatchSize = process.env.EVENTBATCH || 10;
+const eventsBatchSize = process.env.EVENTBATCH || 20;
 const stateBatchSize = process.env.STATEBATCH || 20;
 
 let keys = null;
@@ -274,7 +274,7 @@ function getVultrHosts(group) {
             method: 'GET',
             headers: { "Authorization": `Bearer ${vultrApiKey}` }
         });
-        
+
         const vms = (await resp.json()).instances;
         const ips = vms.sort((a, b) => (a.label < b.label) ? -1 : 1).map(i => i.main_ip);
         resolve(ips);


### PR DESCRIPTION
- Increasing event batch size in stream.js from 10 to 20.
- Adding -f option when removing dist folder in merging operation in js_client package.json script. It suppresses the error in the event there is no dist folder available. (rm: cannot remove 'dist': No such file or directory)