### PR TITLE
Increase MAX_IN_MSG_QUEUE

### DIFF
--- a/src/comm/comm_session.cpp
+++ b/src/comm/comm_session.cpp
@@ -10,7 +10,7 @@ namespace comm
 {
     constexpr uint32_t INTERVALMS = 60000;
     constexpr uint32_t UNVERIFIED_INACTIVE_TIMEOUT = 5000; // Time threshold ms for unverified inactive connections.
-    constexpr uint16_t MAX_IN_MSG_QUEUE_SIZE = 255;        // Maximum in message queue size, The size passed is rounded to next number in binary sequence 1(1),11(3),111(7),1111(15),11111(31)....
+    constexpr uint16_t MAX_IN_MSG_QUEUE_SIZE = 4095;        // Maximum in message queue size, The size passed is rounded to next number in binary sequence 1(1),11(3),111(7),1111(15),11111(31)....
 
     comm_session::comm_session(corebill::tracker &violation_tracker,
                                std::string_view host_address, hpws::client &&hpws_client, const bool is_ipv4, const bool is_inbound, const uint64_t (&metric_thresholds)[5], const bool corebill_enabled)


### PR DESCRIPTION
Increase MAX_IN_MSG_QUEUE to 12bits binary (4095) to handle larger UNL of 64 messaging